### PR TITLE
example nginx: remove includeSubDomains from hsts

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -47,7 +47,7 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
 
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  add_header Strict-Transport-Security "max-age=31536000";
 
   location / {
     try_files $uri @proxy;


### PR DESCRIPTION
most of the nginx example config is safe to copy and paste, it will either work or not but it won't break anything, but a HSTS header with includeSubDomains, cached for a year, will break anything hosted on a subdomain that does not have https, and it is hard to undo

considering mastodon only uses the one domain, i don't think it should bother itself with whether subdomains have HSTS or not